### PR TITLE
Console window size and bright colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "auto-buy a coin with some config settings",
   "main": "pumpBot.js",
   "dependencies": {
-    "colors": "^1.1.2",
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",
     "terminal-kit": "^1.14.3"


### PR DESCRIPTION
- Added a check on startup to ensure the window size is large enough to display all data
- Change colors to their respective brighter versions for clarity purposes (Like red being hard to see)
- Added a number counter (Timestamps don't seem plausible/doable at the moment)
- Added Y/N check back, was removed accidentally
- Fixed "A few" of the live trade print results, need to do more live trade testing to see where everything is printing. Should still be useable over all, however.